### PR TITLE
Adjust workflows for changelog generation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
 
+
 jobs:
   changelog:
     name: Generate changelog
@@ -12,17 +13,25 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Create Token
+        id: create_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "✏️ Generate release changelog"
         uses: heinrichreimer/action-github-changelog-generator@v2.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Commit CHANGELOG.md
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: planetscale/ghcommit-action@v0.1.33
         with:
+          repo: ${{ github.repository }}
           branch: master
           commit_message: 'docs: update CHANGELOG.md for ${{ github.ref_name }} [skip ci]'
           file_pattern: CHANGELOG.md
+        env:
+          GITHUB_TOKEN: ${{ steps.create_token.outputs.token }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:
@@ -11,12 +15,14 @@ jobs:
         nim: [1.6.16, stable]
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
+
     - name: Install Nim
-      uses: iffy/install-nim@v3
+      uses: iffy/install-nim@v4
       with:
         version: ${{ matrix.nim }}
     - name: Build
       run: nimble install -y
+
     - name: Test
       run: nimble test -y


### PR DESCRIPTION
Hey, @emizzle

This is a try to workaround some issue we experience with automated changelog generation.

 **1. Bypass PR request rule**
In order to bypass PR requirements we can
- Use GitHub account with PAT
- Use GitHub App with PAT genereted using private key - we follow that way

After that, we can specify user/app in the bypass list.

Related discussion - [[Feature Request] Allow github actions to bypass branch protection rules in certain specific circumstances #13836](https://github.com/orgs/community/discussions/13836)

**2. Bypass checks**
Currently we have 2 separate workflows which run simultaneously on master merge, but `CI` one is not necessary finished when `changelog` is running. In that way changelog fail, because 2 required checks are not passed. I didn't check how we can run workflows sequentially, but [ruleset](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) solve that.

**3. Meet signed commits requirement**
This step is with more details and we've switched from [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action) to [planetscale/ghcommit-action](https://github.com/planetscale/ghcommit-action), to not use GPG. [Ruleset](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets) can solve that as well, but let's have signed commits?

Related discussion - [Support Signed Commits by actions@github.com #667](https://github.com/actions/runner/issues/667).

**Additional changes**
- `actions/checkout` updated to the latest one
- `iffy/install-nim` updated to the latest one
- `ci` run on push is limited for master only to not run it twice on pr
- unified style (spacing) for `ci.yml` and `changelog.yml`
- all possible rules moved from [Branch protection rules](https://github.com/codex-storage/nim-serde/settings/branches) to [Rulesets](https://github.com/codex-storage/nim-serde/settings/rules)

**Next?**
Let's run and check how it works :)