### PR TITLE
fix: UInt256 not correctly deserializing from string

### DIFF
--- a/serde/json/deserializer.nim
+++ b/serde/json/deserializer.nim
@@ -126,8 +126,11 @@ proc fromJson*[T: distinct](_: type T, json: JsonNode): ?!T =
 proc fromJson*(T: typedesc[StUint or StInt], json: JsonNode): ?!T =
   expectJsonKind(T, JString, json)
   let jsonStr = json.getStr
-  let prefix = if jsonStr.len >= 2: jsonStr[0 .. 1].toLowerAscii
-               else: jsonStr
+  let prefix =
+    if jsonStr.len >= 2:
+      jsonStr[0 .. 1].toLowerAscii
+    else:
+      jsonStr
   case prefix
   of "0x":
     catch parse(jsonStr, T, 16)
@@ -246,6 +249,12 @@ proc fromJson*[T: ref object or object](_: type seq[T], json: string): ?!seq[T] 
   let jsn = ?JsonNode.parse(json) # full qualification required in-module only
   seq[T].fromJson(jsn)
 
+proc fromJson*(T: typedesc[StUint or StInt], json: string): ?!T =
+  T.fromJson(newJString(json))
+
 proc fromJson*[T: ref object or object](_: type ?T, json: string): ?!Option[T] =
-  let jsn = ?JsonNode.parse(json) # full qualification required in-module only
+  when T is (StUInt or StInt):
+    let jsn = newJString(json)
+  else:
+    let jsn = ?JsonNode.parse(json) # full qualification required in-module only
   Option[T].fromJson(jsn)

--- a/tests/json/testDeserialize.nim
+++ b/tests/json/testDeserialize.nim
@@ -19,29 +19,66 @@ suite "json serialization - deserialize":
     let json = newJString("Second")
     check !MyEnum.fromJson(json) == Second
 
-  test "deserializes UInt256 from an empty string":
+  test "deserializes UInt256 from an empty JString":
     let json = newJString("")
     check !UInt256.fromJson(json) == 0.u256
 
-  test "deserializes UInt256 with no prefix":
+  test "deserializes UInt256 from an empty string":
+    check !UInt256.fromJson("") == 0.u256
+
+  test "deserializes ?UInt256 from an empty JString":
+    let json = newJString("")
+    check !Option[UInt256].fromJson(json) == 0.u256.some
+
+  test "deserializes ?UInt256 from an empty string":
+    check !Option[UInt256].fromJson("") == 0.u256.some
+
+  test "deserializes UInt256 from JString with no prefix":
     let json = newJString("1")
     check !UInt256.fromJson(json) == 1.u256
 
-  test "deserializes UInt256 from hex string representation":
+  test "deserializes ?UInt256 from JString with no prefix":
+    let json = newJString("1")
+    check !Option[UInt256].fromJson(json) == 1.u256.some
+
+  test "deserializes UInt256 from string with no prefix":
+    check !UInt256.fromJson("1") == 1.u256
+
+  test "deserializes ?UInt256 from string with no prefix":
+    check !Option[UInt256].fromJson("1") == 1.u256.some
+
+  test "deserializes UInt256 from hex JString representation":
     let json = newJString("0x1")
     check !UInt256.fromJson(json) == 0x1.u256
 
-  test "deserializes UInt256 from octal string representation":
+  test "deserializes ?UInt256 from hex JString representation":
+    let json = newJString("0x1")
+    check !Option[UInt256].fromJson(json) == 0x1.u256.some
+
+  test "deserializes ?UInt256 from hex string representation":
+    check !Option[UInt256].fromJson("0x1") == 0x1.u256.some
+
+  test "deserializes UInt256 from octal JString representation":
     let json = newJString("0o1")
     check !UInt256.fromJson(json) == 0o1.u256
 
-  test "deserializes UInt256 from binary string representation":
+  test "deserializes ?UInt256 from octal JString representation":
+    let json = newJString("0o1")
+    check !Option[UInt256].fromJson(json) == 0o1.u256.some
+
+  test "deserializes ?UInt256 from octal string representation":
+    check !Option[UInt256].fromJson("0o1") == 0o1.u256.some
+
+  test "deserializes UInt256 from binary JString representation":
     let json = newJString("0b1")
     check !UInt256.fromJson(json) == 0b1.u256
 
-  test "deserializes UInt256 from non-hex string representation":
-    let json = newJString("100000")
-    check !UInt256.fromJson(json) == 100000.u256
+  test "deserializes ?UInt256 from binary JString representation":
+    let json = newJString("0b1")
+    check !Option[UInt256].fromJson(json) == 0b1.u256.some
+
+  test "deserializes ?UInt256 from binary string representation":
+    check !Option[UInt256].fromJson("0b1") == 0b1.u256.some
 
   test "deserializes Int256 with no prefix":
     let json = newJString("1")


### PR DESCRIPTION
UInt256 was being deserialized as an object when being deserialized from a string (not a JString).