### PR TITLE
ci: add matrix status job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,11 @@ jobs:
 
       - name: Test
         run: nimble test -y
+
+  status:
+    if: always()
+    needs: [test]
+    runs-on: ubuntu-latest
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')  || contains(needs.*.result, 'skipped') }}
+        run: exit 1


### PR DESCRIPTION
PR adds matrix status job to decouple branch rules status check from a jobs names which are based on Nim version.