### PR TITLE
chore: remove logs 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nim: [2.0.16, 2.2.4]
+        nim: [2.0.16, 2.2.8]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/nimble.lock
+++ b/nimble.lock
@@ -87,21 +87,6 @@
         "sha1": "d1678f50aa47d113b4e77d41eec2190830b523fa"
       }
     },
-    "chronicles": {
-      "version": "0.12.2",
-      "vcsRevision": "27ec507429a4eb81edc20f28292ee8ec420be05b",
-      "url": "https://github.com/status-im/nim-chronicles",
-      "downloadMethod": "git",
-      "dependencies": [
-        "faststreams",
-        "serialization",
-        "json_serialization",
-        "testutils"
-      ],
-      "checksums": {
-        "sha1": "02febb20d088120b2836d3306cfa21f434f88f65"
-      }
-    },
     "questionable": {
       "version": "0.10.15",
       "vcsRevision": "82d90b67bcfb7f2e918b61dace2ff1a4ced60935",

--- a/serde.nimble
+++ b/serde.nimble
@@ -7,7 +7,6 @@ license = "MIT"
 skipDirs = @["tests"]
 
 # Dependencies
-requires "chronicles >= 0.12.3"
 requires "questionable >= 0.10.13 & < 0.11.0"
 requires "stint"
 requires "stew"

--- a/serde.nimble
+++ b/serde.nimble
@@ -7,7 +7,7 @@ license = "MIT"
 skipDirs = @["tests"]
 
 # Dependencies
-requires "chronicles >= 0.10.3"
+requires "chronicles >= 0.12.3"
 requires "questionable >= 0.10.13 & < 0.11.0"
 requires "stint"
 requires "stew"

--- a/serde/json/deserializer.nim
+++ b/serde/json/deserializer.nim
@@ -202,9 +202,6 @@ proc fromJson*[T: ref object or object](_: type T, json: JsonNode): ?!T =
     of Strict:
       if opts.key notin json:
         return failure newSerdeError("object field missing in json: " & opts.key)
-      elif opts.ignore:
-        # unable to figure out a way to make this a compile time check
-        discard
     of OptIn:
       if not hasDeserializePragma:
         skip = true
@@ -215,8 +212,6 @@ proc fromJson*[T: ref object or object](_: type T, json: JsonNode): ?!T =
     of OptOut:
       if opts.ignore:
         skip = true
-      elif hasDeserializePragma and opts.key == name:
-        discard
 
     if not skip:
       if isOptionalValue:

--- a/serde/json/deserializer.nim
+++ b/serde/json/deserializer.nim
@@ -5,7 +5,6 @@ import std/sets
 import std/strutils
 import std/tables
 import std/typetraits
-import pkg/chronicles except toJson
 import pkg/stew/byteutils
 import pkg/stint
 import pkg/questionable
@@ -19,7 +18,6 @@ import ./types
 import ./helpers
 
 export parser
-export chronicles except toJson
 export stdjson
 export pragmas
 export results
@@ -27,9 +25,6 @@ export sets
 export types
 
 {.push raises: [].}
-
-logScope:
-  topics = "nimserde json deserializer"
 
 template expectJsonKind(
     expectedType: type, expectedKinds: set[JsonNodeKind], json: JsonNode

--- a/serde/json/deserializer.nim
+++ b/serde/json/deserializer.nim
@@ -198,18 +198,10 @@ proc fromJson*[T: ref object or object](_: type T, json: JsonNode): ?!T =
     else:
       res
   ):
-    logScope:
-      field = $T & "." & name
-      mode
-
     let hasDeserializePragma = value.hasCustomPragma(deserialize)
     let opts = getSerdeFieldOptions(deserialize, name, value)
     let isOptionalValue = typeof(value) is Option
     var skip = false # workaround for 'continue' not supported in a 'fields' loop
-
-    # logScope moved into proc due to chronicles issue: https://github.com/status-im/nim-chronicles/issues/148
-    logScope:
-      topics = "serde json deserialization"
 
     case mode
     of Strict:
@@ -217,37 +209,30 @@ proc fromJson*[T: ref object or object](_: type T, json: JsonNode): ?!T =
         return failure newSerdeError("object field missing in json: " & opts.key)
       elif opts.ignore:
         # unable to figure out a way to make this a compile time check
-        warn "object field marked as 'ignore' while in Strict mode, field will be deserialized anyway"
+        discard
     of OptIn:
       if not hasDeserializePragma:
-        trace "object field not marked as 'deserialize', skipping"
         skip = true
       elif opts.ignore:
-        trace "object field marked as 'ignore', skipping"
         skip = true
       elif opts.key notin json and not isOptionalValue:
         return failure newSerdeError("object field missing in json: " & opts.key)
     of OptOut:
       if opts.ignore:
-        trace "object field is opted out of deserialization ('ignore' is set), skipping"
         skip = true
       elif hasDeserializePragma and opts.key == name:
-        warn "object field marked as deserialize in OptOut mode, but 'ignore' not set, field will be deserialized"
+        discard
 
     if not skip:
       if isOptionalValue:
         let jsonVal = json{opts.key}
         without parsed =? typeof(value).fromJson(jsonVal), e:
-          trace "failed to deserialize field",
-            `type` = $typeof(value), json = jsonVal, error = e.msg
           return failure(e)
         value = parsed
 
       # not Option[T]
       elif opts.key in json and jsonVal =? json{opts.key}.catch and not jsonVal.isNil:
         without parsed =? typeof(value).fromJson(jsonVal), e:
-          trace "failed to deserialize field",
-            `type` = $typeof(value), json = jsonVal, error = e.msg
           return failure(e)
         value = parsed
 

--- a/serde/json/serializer.nim
+++ b/serde/json/serializer.nim
@@ -4,7 +4,6 @@ import std/strutils
 import std/tables
 import std/typetraits
 
-import pkg/chronicles except toJson
 import pkg/questionable
 import pkg/stew/byteutils
 import pkg/stint
@@ -18,9 +17,6 @@ export pragmas
 export types
 
 {.push raises: [].}
-
-logScope:
-  topics = "nimserde json serializer"
 
 proc `%`*(s: string): JsonNode =
   newJString(s)

--- a/serde/json/serializer.nim
+++ b/serde/json/serializer.nim
@@ -99,6 +99,9 @@ proc `%`*[T: object or ref object](obj: T): JsonNode =
     of OptOut:
       if opts.ignore:
         skip = true
+    of Strict:
+      # required: Nim case on enum must cover all variants
+      discard
 
     if not skip:
       jsonObj[opts.key] = %value

--- a/serde/json/serializer.nim
+++ b/serde/json/serializer.nim
@@ -99,12 +99,6 @@ proc `%`*[T: object or ref object](obj: T): JsonNode =
     of OptOut:
       if opts.ignore:
         skip = true
-      elif hasSerialize and opts.key == name: # all serialize params are default
-        discard
-    of Strict:
-      if opts.ignore:
-        # unable to figure out a way to make this a compile time check
-        discard
 
     if not skip:
       jsonObj[opts.key] = %value

--- a/serde/json/serializer.nim
+++ b/serde/json/serializer.nim
@@ -13,7 +13,6 @@ import ./stdjson
 import ./pragmas
 import ./types
 
-export chronicles except toJson
 export stdjson
 export pragmas
 export types
@@ -91,35 +90,25 @@ proc `%`*[T: object or ref object](obj: T): JsonNode =
   let mode = T.getSerdeMode(serialize)
 
   for name, value in o.fieldPairs:
-    logScope:
-      field = $T & "." & name
-      mode
-
     let opts = getSerdeFieldOptions(serialize, name, value)
     let hasSerialize = value.hasCustomPragma(serialize)
     var skip = false # workaround for 'continue' not supported in a 'fields' loop
 
-    # logScope moved into proc due to chronicles issue: https://github.com/status-im/nim-chronicles/issues/148
-    logScope:
-      topics = "serde json serialization"
-
     case mode
     of OptIn:
       if not hasSerialize:
-        trace "object field not marked with serialize, skipping"
         skip = true
       elif opts.ignore:
         skip = true
     of OptOut:
       if opts.ignore:
-        trace "object field opted out of serialization ('ignore' is set), skipping"
         skip = true
       elif hasSerialize and opts.key == name: # all serialize params are default
-        warn "object field marked as serialize in OptOut mode, but 'ignore' not set, field will be serialized"
+        discard
     of Strict:
       if opts.ignore:
         # unable to figure out a way to make this a compile time check
-        warn "object field marked as 'ignore' while in Strict mode, field will be serialized anyway"
+        discard
 
     if not skip:
       jsonObj[opts.key] = %value


### PR DESCRIPTION
The logs included in the serializer and deserializer were not working with the file-level `logScope` due to this [bug](https://github.com/status-im/nim-chronicles/issues/121).

As a workaround, the `logScope` was moved inside the proc.

However, this introduces `gcsafe` errors with the latest version of Chronicles.

The bug has existed for years (since 2022) and appears to be somewhat complex to fix. For this reason, the simplest way to resolve the issue is to remove the logs from the affected procs.

By removing these logs, we also eliminate the only usage of Chronicles in nim-serde, allowing the dependency to be removed as well.